### PR TITLE
Fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ deploy:
   provider: pages
   skip_cleanup: true
   keep-history: false
-  local_dir: book/
+  local_dir: book/html
   github_token: $GITHUB_API_KEY
   on:
     branch: master


### PR DESCRIPTION
mdbook makes subdirs when there's more than one backend.